### PR TITLE
Ignore not required columns of input & add output as new RTP column in spell.R

### DIFF
--- a/galaxy/spell.R
+++ b/galaxy/spell.R
@@ -22,9 +22,13 @@ testing  <- centerTrain[-toTrain,]
 
 keras <- load_model_hdf5(args[2])
 
-data <- read_tsv(args[3])
+full.data <- read_tsv(args[3])
+
+data <- full.data[,c("Name","InChIKey","SMILES")]
 desc <- getCD(data)
 
 rt <- RT.spell(training,desc,model=keras,cesc=preProc)
 
-write_tsv(rt,args[4])
+full.data$RTP <- rt[,"RTP"]
+
+write_tsv(full.data,args[4])


### PR DESCRIPTION
Adding robustness and usability in workflows to the implementation, no need to change Galaxy wrappers.