### PR TITLE
implemented relative filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN Rscript -e "install.packages('readr',repos='${MIRROR}')"
 
 RUN apt -y install libhdf5-dev
 RUN Rscript -e "install.packages('hdf5r',repos='${MIRROR}')"
+RUN Rscript -e "install.packages('argparser',repos='${MIRROR}')"
 
 WORKDIR /
 

--- a/galaxy/filter_rt.R
+++ b/galaxy/filter_rt.R
@@ -1,22 +1,76 @@
 library(Retip)
 library(hdf5r)
+library(argparser)
 
 ds.name = "/annotation"	# xMSAnnotator
+rt.name = "rt"
+rtp.name = "rtp"
 
-args <- commandArgs(trailingOnly = TRUE)
-if (length(args) != 3) stop("usage: filter_rt.R tolerance in.h5 out.h5") 
+p <- arg_parser("filter_rt.R")
+p <- add_argument(p,c("--tolerance","--mode","input","output"),
+			default=list(10,"absolute","in.h5","out.h5"),
+			help=c("tolerance of RT difference in %",
+				"mode of operation: absolute, relative (min-max), order",
+				"input file", "output file")
+)
 
-data.h5 <- H5File$new(args[2],mode="r")
+argv <- parse_args(p,commandArgs(trailingOnly = TRUE))
+# if (length(args) != 3) stop("usage: filter_rt.R tolerance in.h5 out.h5") 
+
+data.h5 <- H5File$new(argv$input,mode="r")
 data.ds <- data.h5[[ds.name]]
 full.data <- data.ds[]
 
-tol <- as.numeric(args[1]) / 100.
+tol <- as.numeric(argv$tolerance) / 100.
 
 # XXX: hardcoded column names
 # rt from xMSAnnotator, rtp from spell_h5.R
 
-filtered <- full.data[ abs(full.data$rt - full.data$rtp)/full.data$rt < tol, ]
+if (is.null(full.data[[rt.name]]) | is.null(full.data[[rtp.name]])) stop(argv$input, ": must contain ",rt.name," and ",rtp.name," columns")
 
-out=H5File$new(args[3],mode="w")
+if (argv$mode == "absolute") {
+	sel <- abs(full.data[[rt.name]] - full.data[[rtp.name]])/full.data[[rt.name]] < tol
+	print("selection:")
+	print(sel)
+	filtered <- full.data[ sel, ]
+} else if (argv$mode == "relative") {
+	min.rt <- min(full.data[[rt.name]])
+	max.rt <- max(full.data[[rt.name]])
+	min.rtp <- min(full.data[[rtp.name]])
+	max.rtp <- max(full.data[[rtp.name]])
+
+# debug hack
+#	min.rt <- min.rt - 3
+#	min.rtp <- min.rtp - .2
+
+	if (min.rt == max.rt | min.rtp == max.rtp) stop("relative mission impossible, min == max")
+
+	norm.rt <- (full.data[[rt.name]] - min.rt)/(max.rt - min.rt)
+	print("normalized rt:")
+	print(norm.rt)
+	norm.rtp <- (full.data[[rtp.name]] - min.rtp)/(max.rtp - min.rtp)
+	print("normalized rtp:")
+	print(norm.rtp)
+	sel <- abs(norm.rt - norm.rtp)/norm.rt < tol
+	print("selection:")
+	print(sel)
+	filtered <- full.data[ sel, ]
+} else if (argv$mode == "order") {
+	order.rt <- sort.list(full.data[[rt.name]])
+	order.rtp <- sort.list(full.data[[rtp.name]])
+	print("rt order:")
+	print(order.rt)
+	print("rtp order:")
+	print(order.rtp)
+	sel <- abs(order.rt - order.rtp)/length(order.rt) < tol
+	print("selection:")
+	print(sel)
+	filtered <- full.data[ sel, ]
+} else {
+	stop("invalid --mode")
+}
+	
+
+out=H5File$new(argv$output,mode="w")
 out[[ds.name]] <- filtered
 out$close_all()


### PR DESCRIPTION
filter_rt.R supports three filtering modes now:

- absolute (original): only records with |RT - RTP| < tolerance  pass
- relative: both RT and RTP are mapped to [0;1] first (independently) and compared on this scale
- order: only relative order of RT and RTP is taken in account for comparison

In all modes, tolerance is specified in percent.

This commit also changes invocation of the command, hence the Galaxy wrapper must be changed too. The usage is:

filter_rt.R --tolerance NN --mode MODE input.h5 output.h5

where NN is the tolerance (percent) and mode is one of absolute, relative, or order. 

Mode should become a new option to be choosen by the user of the Galaxy tool too.