### PR TITLE
Adapt to larger inputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN rm -rf /build/retip
 
 RUN Rscript -e "install.packages('readxl',repos='${MIRROR}')"
 RUN Rscript -e 'reticulate::install_miniconda()'
-RUN bash -c "source /root/.local/share/r-miniconda/bin/activate r-reticulate && Rscript -e 'library(keras); install_keras()'"
+RUN bash -c "source /root/.local/share/r-miniconda/bin/activate r-reticulate && conda install keras"
+#RUN bash -c "source /root/.local/share/r-miniconda/bin/activate r-reticulate && Rscript -e 'library(keras); install_keras()'"
 
 RUN Rscript -e "install.packages('readr',repos='${MIRROR}')"
 # RUN Rscript -e "install.packages('feather',repos='${MIRROR}')"

--- a/galaxy/chemdesc.R
+++ b/galaxy/chemdesc.R
@@ -9,6 +9,9 @@ if (length(args) != 2) stop("usage: chemdesc.R compounds.tsv descriptors.h5")
 
 data <- read_tsv(args[1])
 desc <- proc.data(getCD(data))
+
+# keep as extra column rather than attributes
+desc$SMILES <- rownames(desc)
 #write_feather(desc,args[2])
 
 out=H5File$new(args[2],mode="w")
@@ -17,8 +20,9 @@ out=H5File$new(args[2],mode="w")
 # out[["/desc"]] <- desc[4:ncol(desc)]
 out[["/desc"]] <- desc
 
-ds <- out[["/desc"]]
-h5attr(ds,"rownames") <- rownames(desc)
+# broken with high nrow
+# ds <- out[["/desc"]]
+# h5attr(ds,"rownames") <- rownames(desc)
 out$close_all()
 
 #print(desc)

--- a/galaxy/spell.R
+++ b/galaxy/spell.R
@@ -10,6 +10,7 @@ prep.wizard()
 desc <- H5File$new(args[1],mode="r")
 ds <- desc[["/desc"]]
 cleanTrain <- ds[]
+cleanTrain$SMILES <- NULL
 
 preProc <- cesc(cleanTrain)
 centerTrain <- predict(preProc,cleanTrain)

--- a/galaxy/spell_h5.R
+++ b/galaxy/spell_h5.R
@@ -16,6 +16,7 @@ prep.wizard()
 desc <- H5File$new(args[1],mode="r")
 ds <- desc[["/desc"]]
 cleanTrain <- ds[]
+cleanTrain$SMILES <- NULL
 
 preProc <- cesc(cleanTrain)
 centerTrain <- predict(preProc,cleanTrain)

--- a/galaxy/trainKeras.R
+++ b/galaxy/trainKeras.R
@@ -11,7 +11,8 @@ desc <- H5File$new(args[1],mode="r")
 ds <- desc[["/desc"]]
 cleanTrain <- ds[]
 #ht5attr_names(ds)
-row.names(cleanTrain) <- h5attr(ds,"rownames")
+row.names(cleanTrain) <- cleanTrain$SMILES
+cleanTrain$SMILES <- NULL
 
 preProc <- cesc(cleanTrain)
 centerTrain <- predict(preProc,cleanTrain)


### PR DESCRIPTION
1. run chemical descriptors computation in parallel on all available cores
2. do not store SMILES in H5 file attributes -- there is a size limit (64k entries?), larger datasets fail to be stored
3. resolve dependency problem -- due to some 3rd party package updates, installation via R's install_keras() broke tensorflow wrt. scipy and h5py; direct installation with conda seems to bring in mutually versions

The second point breaks compatibility at the h5 files level (output of chemdesc.R vs. all the others) but we are in a stage we can live with it.