### PR TITLE
xMSAnnotator dec2020

### DIFF
--- a/galaxy/spell.R
+++ b/galaxy/spell.R
@@ -33,6 +33,14 @@ desc <- getCD(data)
 
 rt <- RT.spell(training,desc,model=keras,cesc=preProc)
 
-full.data$rtp <- rt[,"RTP"]
+good <- which(full.data$molecular_formula %in% rt$Name)
+out.data <- full.data[good,]
 
-write_tsv(full.data,args[4])
+out.data$rtp <- rt[,"RTP"]
+
+print(paste0("input rows: ",nrow(full.data)))
+print(paste0("descriptors computed: ",nrow(desc)))
+print(paste0("RT predicted: ",nrow(rt)))
+print(paste0("output rows: ",nrow(out.data)))
+
+write_tsv(out.data,args[4])

--- a/galaxy/spell.R
+++ b/galaxy/spell.R
@@ -5,6 +5,8 @@ library(readr)
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) != 4) stop("usage: spell.R descr-train.h5 model.h5 in.tsv out.tsv") 
 
+columns = c("molecular_formula","molecular_formula","qsar_smiles")
+
 prep.wizard()
 
 desc <- H5File$new(args[1],mode="r")
@@ -25,11 +27,12 @@ keras <- load_model_hdf5(args[2])
 
 full.data <- read_tsv(args[3])
 
-data <- full.data[,c("Name","InChIKey","SMILES")]
+data <- full.data[,columns]
+names(data) <- c("Name","InChIKey","SMILES")
 desc <- getCD(data)
 
 rt <- RT.spell(training,desc,model=keras,cesc=preProc)
 
-full.data$RTP <- rt[,"RTP"]
+full.data$rtp <- rt[,"RTP"]
 
 write_tsv(full.data,args[4])

--- a/galaxy/spell_h5.R
+++ b/galaxy/spell_h5.R
@@ -5,8 +5,9 @@ library(readr)
 # path and dataset name (XXX: hardcoded in xMSAnnotator)
 ds.name = "/annotation"
 
-# column name to hope for SMILES
-smiles.name = "compound"
+# XXX: columns to feed to retip: it wants Name, InChIKey, SMILES but does not use the first two
+# and this is what we have
+columns = c("molecular_formula","molecular_formula","qsar_smiles")
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) != 4) stop("usage: spell_h5.R descr-train.h5 model.h5 in.h5 out.h5") 
@@ -35,7 +36,7 @@ data.h5 <- H5File$new(args[3],mode="r")
 data.ds <- data.h5[[ds.name]]
 full.data <- data.ds[]
 
-data <- full.data[,c(smiles.name,smiles.name,smiles.name)]
+data <- full.data[,columns]
 
 # XXX: rename to what Retip expects
 names(data) <- c("Name","InChIKey","SMILES")

--- a/galaxy/spell_h5.R
+++ b/galaxy/spell_h5.R
@@ -44,9 +44,17 @@ desc <- getCD(data)
 
 rt <- RT.spell(training,desc,model=keras,cesc=preProc)
 
-full.data$rtp <- rt[,"RTP"]
+good <- which(full.data$molecular_formula %in% rt$Name)
+out.data <- full.data[good,]
+
+out.data$rtp <- rt[,"RTP"]
+
+print(paste0("input rows: ",nrow(full.data)))
+print(paste0("descriptors computed: ",nrow(desc)))
+print(paste0("RT predicted: ",nrow(rt)))
+print(paste0("output rows: ",nrow(out.data)))
 
 out=H5File$new(args[4],mode="w")
-out[[ds.name]] <- full.data
+out[[ds.name]] <- out.data
 out$close_all()
 


### PR DESCRIPTION
Adapt to xMSAnnotator changes of Dec 2020 (column naming etc.)

Also add some robustness on partial failures (some descriptiors/rt predictions fail)

Already pushed to dockerhub as recetox/retip:0.5.4-recetox4 (blame me if I should have not done so)